### PR TITLE
Mn self intro

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1999,6 +1999,9 @@ bool BlockchainLMDB::get_txpool_tx_blob(const crypto::hash& txid, cryptonote::bl
   if (result != 0)
       throw1(DB_ERROR(lmdb_error("Error finding txpool tx blob: ", result).c_str()));
 
+  if (v.mv_size == 0)
+      throw1(DB_ERROR("Error finding txpool tx blob: tx is present, but data is empty"));
+
   bd.assign(reinterpret_cast<const char*>(v.mv_data), v.mv_size);
   return true;
 }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1156,7 +1156,13 @@ namespace cryptonote
       tx_info.tvc.m_too_big = true;
       return;
     }
-
+    else if (tx_info.blob->empty())
+    {
+      LOG_PRINT_L1("WRONG TRANSACTION BLOB, blob is empty, rejected");
+      tx_info.tvc.m_verifivation_failed = true;
+      return;
+    }
+    
     tx_info.parsed = parse_and_validate_tx_from_blob(*tx_info.blob, tx_info.tx, tx_info.tx_hash);
     if(!tx_info.parsed)
     {

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2788,10 +2788,8 @@ skip:
     m_p2p->for_each_connection([&](const connection_context& cntxt, nodetool::peerid_type peer_id, uint32_t support_flags) {
       MINFO("DEBUGconnection state:" << cntxt.m_state  << " cntxtId:" << cntxt.m_connection_id << " context:"<<context.m_connection_id);
       if (cntxt.m_state >= cryptonote_connection_context::state_synchronizing && cntxt.m_connection_id != context.m_connection_id)
-      {
         target = std::max(target, cntxt.m_remote_blockchain_height);
         MINFO("Target found:" << target);
-      }
       return true;
     });
     const uint64_t previous_target = m_core.get_target_blockchain_height();


### PR DESCRIPTION
- Added fail message if tx_blob is empty.

- Now detects when on_transaction_relayed fails to parse, it returns a null_hash. Also eliminated calling 'on_transaction_relayed(tx_blob)' twice.

- When we pass the blob into parse_and_validate_tx_from_blob we get 'deserialization or variant failed' error log which is of a high severity. Now we catch the empty blob case earlier and log it at a lesser severity.

- Currently we're putting the last-uptime-received data in the master node list info, even when we have more updated info that hasn't yet been accepted by the network.
 
- This cause problems for belnet in particular, After the MNs becomes registered, the belnet still thinks it is deregistered until the proof is submitted.
 
- This updates get_master_nodes to always include current info (rather than latest proof info) for itself when querying a master node.